### PR TITLE
Remove final from SaneOption

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneOption.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneOption.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
  *
  * @author James Ring (sjr@jdns.org)
  */
-public final class SaneOption {
+public class SaneOption {
 
   private static final Logger logger = Logger.getLogger(SaneOption.class.getName());
 


### PR DESCRIPTION
Since final classes can't be mocked with regular mockito it's more useful to not be final.